### PR TITLE
Tinypilot Janus integration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,3 +101,4 @@ janus_conf_template:
   janus.transport.http.jcfg: janus.transport.http.jcfg
   janus.transport.pfunix.jcfg: janus.transport.pfunix.jcfg
   janus.transport.websockets.jcfg: janus.transport.websockets.jcfg
+  janus.plugin.ustreamer.jcfg: janus.plugin.ustreamer.jcfg

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -8,7 +8,6 @@
   ansible.builtin.file:
     path: "{{ janus_workspace_dir }}"
     state: directory
-    mode: "770"
     recurse: true
     
 - name: Install libnice

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -72,6 +72,19 @@
     chdir: "{{ janus_build_dir }}"
   when: janus_upgrade_available
 
+# Allow Janus C header files to be included when compiling third-party plugins.
+- name: Symlink Janus C header files to the C include path
+  file:
+    src: "{{ janus_install_dir }}/include/janus"
+    dest: /usr/local/include/janus
+    state: link
+
+# We're unable to build the uStreamer Janus plugin because the include statement
+# references the wrong file path.
+# TODO: Create a PR to patch this bug in the janus-gateway repo.
+- name: Patch plugin.h file to successfully include refcount.h file
+  command: sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' "{{ janus_install_dir }}/include/janus/plugins/plugin.h"
+
 - name: Set installed version facts
   ansible.builtin.set_fact:
     janus_installed_versions:  

--- a/templates/janus.plugin.ustreamer.jcfg
+++ b/templates/janus.plugin.ustreamer.jcfg
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+memsink: {
+	object = "{{ ustreamer_h264_sink | default("janus::ustreamer::h264") }}"
+}


### PR DESCRIPTION
This PR is part of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/168

This PR adds the least possible changes needed to reliably install the Janus Gateway on a device running TinyPilot.

I've deliberately maintained the style of the current ansible role to keep these changes in scope of the [original task](https://github.com/tiny-pilot/ansible-role-tinypilot/issues/168). However, I suggest we revise the design of this ansible role (in a follow-up PR) with the goal of either purging config files/variables we don't need or making the role more customizable to skip the parts we don't need.